### PR TITLE
v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.0
+
+Updates `librpitx` to newly released version supporting rpi4 devices
+See [the release announcement](https://groups.io/g/rpitx/topic/pi4_release_available/78004061?p=,,,20,0,0,0::recentpostdate%2Fsticky,,,20,2,0,78004061) or the [referenced commit](https://github.com/F5OEO/librpitx/tree/0aec0363e26867e7be75f52b9d0e22e8518a4eb0)
+for more details
+
 ## v0.2.2
 
 Update `librpitx`

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@
 # CFLAGS	compiler flags for compiling all C files
 # LDFLAGS	linker flags for linking all binaries
 
-LIBRPITX_VERSION = 5c1613589d8b89287f5af20c53145bc63ebc2d6f
+LIBRPITX_VERSION = 0aec0363e26867e7be75f52b9d0e22e8518a4eb0
+PATCH_DIRS = $(TOP)/patches/librpitx
+LDFLAGS += -lbcm_host
 
 TOP := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 SRC_TOP = $(TOP)/src
@@ -44,7 +46,6 @@ ifeq ($(SED),)
 endif
 
 MAKE_OPTS += SED=$(SED)
-PATCH_DIRS = $(TOP)/patches/librpitx
 
 ifeq ($(CROSSCOMPILE),)
 $(warning Native OS compilation is not supported on OSX. Skipping compilation.)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,8 @@
 defmodule Replex.MixProject do
   use Mix.Project
 
-  @version "0.2.2"
+  @version "0.3.0"
+  @source_url "https://github.com/jjcarstens/replex"
 
   def project do
     [
@@ -37,10 +38,11 @@ defmodule Replex.MixProject do
 
   defp docs do
     [
-      extras: ["README.md"],
+      extras: ["README.md", "CHANGELOG.md"],
       main: "readme",
       source_ref: "v#{@version}",
-      source_url: "https://github.com/jjcarstens/replex"
+      source_url: @source_url,
+      skip_undefined_reference_warnings_on: ["CHANGELOG.md"]
     ]
   end
 
@@ -56,7 +58,7 @@ defmodule Replex.MixProject do
         "README.md",
         "src/.keep"
       ],
-      links: %{"Github" => "https://github.com/jjcarstens/replex"},
+      links: %{"Github" => @source_url},
       licenses: ["Apache-2.0"]
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,10 @@
 %{
-  "earmark": {:hex, :earmark, "1.3.5", "0db71c8290b5bc81cb0101a2a507a76dca659513984d683119ee722828b424f6", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.6.0", "38349f3e29aff4864352084fc736fa7fa0f2995a819a737554f7ebd28b85aaab", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.1", "5ac36660846967cd869255f4426467a11672fec3d8db602c429425ce5b613b90", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.5", "0db71c8290b5bc81cb0101a2a507a76dca659513984d683119ee722828b424f6", [:mix], [], "hexpm", "762b999fd414fb41e297944228aa1de2cd4a3876a07f968c8b11d1e9a2190d07"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
+  "elixir_make": {:hex, :elixir_make, "0.6.1", "8faa29a5597faba999aeeb72bbb9c91694ef8068f0131192fb199f98d32994ef", [:mix], [], "hexpm", "35d33270680f8d839a4003c3e9f43afb595310a592405a00afc12de4c7f55a18"},
+  "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},
   "exceptional": {:hex, :exceptional, "2.1.1", "f18f8c1be63aab7fe8f3000cf2a8678936544fc39af1e2bc4a5c3c9e38cd8899", [:mix], [], "hexpm"},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.0", "98312c9f0d3730fde4049985a1105da5155bfe5c11e47bdc7406d88e01e4219b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "75ffa34ab1056b7e24844c90bfc62aaf6f3a37a15faa76b07bc5eba27e4a8b4a"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
 }

--- a/patches/librpitx/0001-Allow-compiler-option-overrides-for-crosscompilation.patch
+++ b/patches/librpitx/0001-Allow-compiler-option-overrides-for-crosscompilation.patch
@@ -1,6 +1,6 @@
-From 6c792dd0bc06764ca40e4b75b0dd2cfcb6a18f8c Mon Sep 17 00:00:00 2001
-From: Frank Hunleth <fhunleth@troodon-software.com>
-Date: Thu, 22 Aug 2019 09:33:12 -0400
+From 09fcf073731c6a0904b7af36148d3edcd6780b9e Mon Sep 17 00:00:00 2001
+From: Jon Carstens <jjcarstens@me.com>
+Date: Mon, 26 Oct 2020 09:21:30 -0600
 Subject: [PATCH] Allow compiler option overrides for crosscompilation
 
 ---
@@ -8,18 +8,18 @@ Subject: [PATCH] Allow compiler option overrides for crosscompilation
  1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/src/Makefile b/src/Makefile
-index 4cc2324..cffa0dc 100644
+index 012c34e..f8c9255 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -1,13 +1,13 @@
 -CFLAGS = -Wall -O3 -Wno-unused-variable
--CXXFLAGS = -std=c++11 -Wall -O3 -Wno-unused-variable
--LDFLAGS = -lm -lrt -lpthread
+-CXXFLAGS = -std=c++11 -Wall -O3 -Wno-unused-variable -I /opt/vc/include 
+-LDFLAGS = -lm -lrt -lpthread -L/opt/vc/lib -lbcm_host
 -CCP = c++
 -CC = cc
 +CFLAGS += -Wall -O3 -Wno-unused-variable
-+CXXFLAGS += -std=c++11 -Wall -O3 -Wno-unused-variable
-+LDFLAGS += -lm -lrt -lpthread
++CXXFLAGS += -std=c++11 -Wall -O3 -Wno-unused-variable -I /opt/vc/include 
++LDFLAGS += -lm -lrt -lpthread -L/opt/vc/lib -lbcm_host
 +CXX ?= c++
 +CC ?= cc
  
@@ -32,5 +32,5 @@ index 4cc2324..cffa0dc 100644
  
  install: librpitx
 -- 
-2.20.1 (Apple Git-117)
+2.20.1
 


### PR DESCRIPTION
* Fixes support for `rpi4` targets. Resolves #8 
* updates `librpitx` to support rpi4